### PR TITLE
Clarified that releases should be done in the user's repo

### DIFF
--- a/docs/thoth-aicoe-services.md
+++ b/docs/thoth-aicoe-services.md
@@ -174,7 +174,7 @@ Once you modify the `.aicoe.yaml` push the changes to your repo. Check [push cha
 
 ## Create new release
 
-Now that everything is set you can create new images. Some of the pipelines used in the Thoth project are maintained by bots. Therefore you can simply open an issue asking for a release (e.g patch, minor, major) and the bots will handle your request. Once the request is completed, the bot will also automatically close the issue, as you can see from the images below:
+Now that everything is set you can create new images. Some of the pipelines used in the Thoth project are maintained by bots. Therefore you can simply open an issue asking for a release from the repo you maintain (e.g patch, minor, major) and the bots will handle your request. Once the request is completed, the bot will also automatically close the issue, as you can see from the images below:
 
 <div style="text-align:center">
 <img alt="Open Issue Release" src="https://raw.githubusercontent.com/AICoE/manage-dependencies-tutorial/master/docs/images/KhebutOpenIssueRelease.png">


### PR DESCRIPTION
Changed the text in `docs/thoth-aicoe-services.md` to clarify that the new release should be made on the repo maintained by the user.

/assign @pacospace 