### PR TITLE
Fix a link in pre-requisites page

### DIFF
--- a/docs/source/pre-requisite.md
+++ b/docs/source/pre-requisite.md
@@ -2,11 +2,11 @@
 
 | pre-requisite | notes |
 | ------------- | ------------------ |
-| GitHub account | The project is based on GitHub, if you don't have one account, just follow this [link](https://docs.github.com/en/github/getting-started-with-github/signing-up-for-a-new-github-account). |
-| GitHub token |  If you don't have a GitHub token, you can create one following GitHub docs: [create GitHub token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token). |
+| GitHub account | The project is based on GitHub, if you don't have an account, just follow this [link][15]. |
+| GitHub token |  If you don't have a GitHub token, you can create one following GitHub docs: [create GitHub token][16]. |
 | [Red Hat Openshift][1] |  Using [Operate First][2] you can find a deployed [Red Hat Openshift][1] available to [Operate First][2] community. |
 | [Open Data Hub][3] |  Using [Operate First][2] you can find a community supported [Open Data Hub][3] with all tools for Data Science (e.g. [JupyterHub][4], [Elyra][5], [Kubeflow Pipelines][6], [Seldon][7], [Prometheus][8], [Grafana][9], [Superset][10]) running on [Red Hat Openshift][1]. |
-| JupyterLab environment with [jupyterlab-requirements][11] library and [Elyra][5] |  Using [Operate First][1], you can login in [JupyterHub][4] with your GitHub Account and you can spawn the image called [Experimental Elyra Notebook Image](https://github.com/operate-first/apps/blob/master/kfdefs/base/jupyterhub/notebook-images/experimental-elyra-notebook-imagestream.yaml), which has the library for dependency management already installed. If you use [Meteor][12], it will build a [JupyterHub][4] environment for your project from the GitHub repository URL you provide to it. (e.g. this [URL](https://github.com/pacospace/manage-dependencies-tutorial/)). |
+| JupyterLab environment with [jupyterlab-requirements][11] library and [Elyra][5] |  Using [Operate First][2], you can login in [JupyterHub][4] with your GitHub Account and you can spawn the image called [Experimental Elyra Notebook Image][13], which has the library for dependency management already installed. If you use [Meteor][12], it will build a [JupyterHub][4] environment for your project from the GitHub repository URL you provide to it. (e.g. this [URL][14]). |
 
 
 ## Next Step
@@ -41,3 +41,7 @@
 [10]: https://superset.apache.org/
 [11]: https://github.com/thoth-station/jupyterlab-requirements
 [12]: https://github.com/AICoE/meteor
+[13]: https://github.com/operate-first/apps/blob/master/kfdefs/base/jupyterhub/notebook-images/experimental-elyra-notebook-imagestream.yaml
+[14]: https://github.com/pacospace/manage-dependencies-tutorial/
+[15]: https://docs.github.com/en/github/getting-started-with-github/signing-up-for-a-new-github-account
+[16]: https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token


### PR DESCRIPTION
One of the references to Operate First was actually linking to openshift.com instead of operate-first.cloud.

Taking the opportunity to move all URLs in the page to the bottom for consistency.
